### PR TITLE
Set a default date - 10 days to prevent event too old to be retrieved by the application.

### DIFF
--- a/api/events/views.py
+++ b/api/events/views.py
@@ -1,4 +1,6 @@
 import json
+from datetime import datetime, timedelta
+
 from rest_framework import viewsets
 from rest_framework import permissions
 from events.models import Event
@@ -27,8 +29,12 @@ class EventViewSet(viewsets.ModelViewSet):
         If both start and end are specified, duration is ignored.
         duration is used if only start or end is specified.
         """
+        # Build the date from 10 days ago to not retrieve by default all events since the account creation.
+        current_datetime = datetime.now()
+        date_minus_10_days = current_datetime - datetime.timedelta(days=10)
+        formatted_start_date_by_default = date_minus_10_days.strftime("%Y-%m-%d %H:%M:%S")
         user = self.request.query_params.get('user', None)
-        startDateStr = self.request.query_params.get('start', None)
+        startDateStr = self.request.query_params.get('start', formatted_start_date_by_default)
         endDateStr = self.request.query_params.get('end', None)
         durationMinStr = self.request.query_params.get('duration', None)
         authUser = self.request.user


### PR DESCRIPTION

Should drastically speed up the event page on the application